### PR TITLE
Custom value for the root attribute

### DIFF
--- a/NestedSet.php
+++ b/NestedSet.php
@@ -779,6 +779,13 @@ class NestedSet extends Behavior
 					return false;
 				}
 
+				if ($this->owner->getAttribute($this->rootAttribute)) {
+					if (isset($transaction)) {
+						$transaction->commit();
+					}
+					return $result;
+				}
+
 				$this->owner->setAttribute($this->rootAttribute, $this->owner->getPrimaryKey());
 				$primaryKey = $this->owner->primaryKey();
 


### PR DESCRIPTION
Доработан метод makeRoot(). Доработка дает возможность задавать пользовательское значение для rootAttribute. Это нужно в случае когда поле таблицы, которое обозначено как rootAttribute, связано по внешнему ключу с другой таблицей. В этом случае установка значения в rootAttribute по primaryKey не подходит.
