### PR TITLE
Replace init with attach

### DIFF
--- a/NestedSet.php
+++ b/NestedSet.php
@@ -80,9 +80,9 @@ class NestedSet extends Behavior
 	/**
 	 * @inheritdoc
 	 */
-	public function init()
+	public function attach($owner)
 	{
-		parent::init();
+		parent::attach($owner);
 		self::$_cached[get_class($this->owner)][$this->_id = self::$_c++] = $this->owner;
 	}
 


### PR DESCRIPTION
On `init()` stage there's no owner(it is null).
Owner appears on `attach()`.

The reason of this pull request is the following error chain.
1. Have an empty multi-root tree
2. Add first node via saveNode()
3. Append new node to previously created using appendTo
4. ???
5. ERROR!!!

Errors:
First error is transaction rollback error:

```

exception 'yii\db\Exception' with message 'Failed to roll back transaction: transaction was inactive.' in /Users/bethrezen/Documents/dotplant2/application/vendor/yiisoft/yii2/db/Transaction.php:103
Stack trace:
#0 /Users/bethrezen/Documents/dotplant2/application/vendor/creocoder/yii2-nested-set-behavior/NestedSet.php(770): yii\db\Transaction->rollback()
#1 /Users/bethrezen/Documents/dotplant2/application/vendor/creocoder/yii2-nested-set-behavior/NestedSet.php(387): creocoder\behaviors\NestedSet->addNode(Object(app\models\NestedContent), 2, 1, true, NULL)
#2 [internal function]: creocoder\behaviors\NestedSet->appendTo(Object(app\models\NestedContent))
#3 /Users/bethrezen/Documents/dotplant2/application/vendor/yiisoft/yii2/base/Component.php(200): call_user_func_array(Array, Array)
#4 /Users/bethrezen/Documents/dotplant2/application/migrations/m131212_112648_base_content.php(165): yii\base\Component->__call('appendTo', Array)
#5 /Users/bethrezen/Documents/dotplant2/application/migrations/m131212_112648_base_content.php(165): app\models\NestedContent->appendTo(Object(app\models\NestedContent))


```

If i make `throw $e;` on line 769 - i'll see the correct error:

```

exception 'yii\base\ErrorException' with message 'Undefined index: app\models\NestedContent' in /Users/bethrezen/Documents/dotplant2/application/vendor/creocoder/yii2-nested-set-behavior/NestedSet.php:1046
Stack trace:
#0 /Users/bethrezen/Documents/dotplant2/application/vendor/creocoder/yii2-nested-set-behavior/NestedSet.php(1046): yii\base\Application->handleError(8, 'Undefined index...', '/Users/bethreze...', 1046, Array)
#1 /Users/bethrezen/Documents/dotplant2/application/vendor/creocoder/yii2-nested-set-behavior/NestedSet.php(767): creocoder\behaviors\NestedSet->correctCachedOnAddNode(2)
#2 /Users/bethrezen/Documents/dotplant2/application/vendor/creocoder/yii2-nested-set-behavior/NestedSet.php(387): creocoder\behaviors\NestedSet->addNode(Object(app\models\NestedContent), 2, 1, true, NULL)
#3 [internal function]: creocoder\behaviors\NestedSet->appendTo(Object(app\models\NestedContent))
#4 /Users/bethrezen/Documents/dotplant2/application/vendor/yiisoft/yii2/base/Component.php(200): call_user_func_array(Array, Array)
#5 /Users/bethrezen/Documents/dotplant2/application/migrations/m131212_112648_base_content.php(165): yii\base\Component->__call('appendTo', Array)
#6 /Users/bethrezen/Documents/dotplant2/application/migrations/m131212_112648_base_content.php(165): app\models\NestedContent->appendTo(Object(app\models\NestedContent))

```

So, it seems that _cached variable is not properly filled.
After some brief looking at code I've noticed strange init function.
