### PR TITLE
fixing the multiple roots problem with updating left, right

### DIFF
--- a/NestedSetsBehavior.php
+++ b/NestedSetsBehavior.php
@@ -427,15 +427,14 @@ class NestedSetsBehavior extends Behavior
         if ($depth === 0 && $this->node->isRoot()) {
             throw new Exception('Can not create a node when the target node is root.');
         }
+        if ($this->treeAttribute !== false) {
+            $this->owner->setAttribute($this->treeAttribute, $this->node->getAttribute($this->treeAttribute));
+        }
 
         $this->shiftLeftRightAttribute($value, 2);
         $this->owner->setAttribute($this->leftAttribute, $value);
         $this->owner->setAttribute($this->rightAttribute, $value + 1);
         $this->owner->setAttribute($this->depthAttribute, $this->node->getAttribute($this->depthAttribute) + $depth);
-
-        if ($this->treeAttribute !== false) {
-            $this->owner->setAttribute($this->treeAttribute, $this->node->getAttribute($this->treeAttribute));
-        }
     }
 
     /**


### PR DESCRIPTION
shiftLeftRightAttribute takes into consideration the root. However the root is not set until after the the other nodes are updated. So this part of shiftLeftRightAttribute

if ($this->treeAttribute !== false) {
                $condition = [
                    'and',
                    $condition,
                    [$this->treeAttribute => $this->owner->getAttribute($this->treeAttribute)]
                ];
            }

Will create a condition with where $this->owner->getAttribute($this->treeAttribute) is empty. As a result no records are changed.