### PR TITLE
Documenting caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,12 @@ class MenuQuery extends \yii\db\ActiveQuery
             NestedSetsQueryBehavior::className(),
         ];
     }
+    
+    public function where($condition) {
+        // Do not allow to break behavior magic
+        return parent::andWhere($condition);
+    }
+    
 }
 ```
 


### PR DESCRIPTION
Using something like `$tree->children(1)->where(['field' => 'value'])` looks valid, but breaks functionality completely.